### PR TITLE
Remove deprecated String listen

### DIFF
--- a/Sources/GraphQLTransportWS/Client.swift
+++ b/Sources/GraphQLTransportWS/Client.swift
@@ -45,20 +45,6 @@ public actor Client<InitPayload: Equatable & Codable> {
         }
     }
 
-    /// Listen and react to the provided async sequence of server messages. This function will block until the stream is completed.
-    /// - Parameter incoming: The server message sequence that the client should react to.
-    @available(*, deprecated, message: "Use `Data` sequence instead.")
-    public func listen<A: AsyncSequence & Sendable>(to incoming: A) async throws
-    where A.Element == String {
-        for try await stringMessage in incoming {
-            guard let message = stringMessage.data(using: .utf8) else {
-                try await self.error(.invalidEncoding())
-                return
-            }
-            try await respond(to: message)
-        }
-    }
-
     private func respond(to message: Data) async throws {
         let response: Response
         do {

--- a/Sources/GraphQLTransportWS/Server.swift
+++ b/Sources/GraphQLTransportWS/Server.swift
@@ -65,21 +65,6 @@ where
         }
     }
 
-    /// Listen and react to the provided async sequence of client messages. This function will block until the stream is completed.
-    /// - Parameter incoming: The client message sequence that the server should react to.
-    @available(*, deprecated, message: "Use `Data` sequence instead.")
-    public func listen<A: AsyncSequence & Sendable>(to incoming: A) async throws
-    where A.Element == String {
-        for try await stringMessage in incoming {
-            guard let message = stringMessage.data(using: .utf8) else {
-                try await error(.invalidEncoding())
-                return
-            }
-
-            try await respond(to: message)
-        }
-    }
-
     private func respond(to message: Data) async throws {
         let request: Request
         do {


### PR DESCRIPTION
This was introduced in https://github.com/GraphQLSwift/GraphQLTransportWS/pull/11, but is no longer needed since we will be releasing a major version